### PR TITLE
Update punycode and actually use it

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "lodash.includes": "^4.3.0",
-    "punycode": "^1.4.1"
+    "punycode": "^2.3.1"
   },
   "types": "src/index.d.ts",
   "directories": {

--- a/src/DomainValidator.js
+++ b/src/DomainValidator.js
@@ -1,8 +1,8 @@
 "use strict"
 
-import * as Domains from "./Domains"
 import includes from 'lodash.includes'
-import * as punycode from 'punycode'
+import * as punycode from 'punycode/'
+import * as Domains from './Domains'
 
 export class DomainValidator {
 	/**
@@ -47,7 +47,7 @@ export class DomainValidator {
 		if (!domain) {
 			return false
 		}
-		
+
 		domain = this._unicodeToASCII(domain)
 		if (domain.length > 253) {
 			return false
@@ -62,7 +62,7 @@ export class DomainValidator {
 		if (!domain) {
 			return false
 		}
-		
+
 		domain = this._unicodeToASCII(domain)
 		if (domain.length > 253) {
 			return false


### PR DESCRIPTION
See https://www.npmjs.com/package/punycode#installation
Because node.js provides a built-in `punycode` module, `import "punycode"` picks up the built-in one.
However, that module is deprecated and shows a warning in the console starting in node 21 see https://nodejs.org/api/punycode.html

The recommended way to import punycode is `import "punycode/"`

I also updated punycode, version 2 removed support for node under v6: https://github.com/mathiasbynens/punycode.js/releases/tag/v2.0.0

You might deem it necessary to do a major bump of this library